### PR TITLE
Add Plexus

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -736,6 +736,13 @@ source = "crates"
 categories = ["2drendering"]
 
 [[items]]
+name = "olson-sean-k/plexus"
+source = "github"
+categories = ["mesh"]
+homepage = "https://plexus.rs"
+crate_url = "https://crates.io/crates/plexus"
+
+[[items]]
 name = "portmidi"
 source = "crates"
 categories = ["audio"]


### PR DESCRIPTION
This change adds [Plexus](https://github.com/olson-sean-k/plexus) to the ecosystem registry in the "mesh" category. Plexus is a polygonal mesh processing crate that I've been developing. It is still missing important features; I'm not sure if there are any requirements for adding a crate to the registry. :sweat_smile: Please take a look. Thanks!